### PR TITLE
Support for fullscreen change events

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -12,6 +12,7 @@
   onChangeState={event => console.log(event)}
   onReady={() => console.log("ready")}
   onError={e => console.log(e)}
+  onFullScreenChange={status => console.log(status)}
   onPlaybackQualityChange={q => console.log(q)}
   volume={50}
   playbackRate={1}
@@ -37,6 +38,7 @@
 - [onChangeState](#onChangeState)
 - [onReady](#onReady)
 - [onError](#onError)
+- [onFullScreenChange](#onFullScreenChange)
 - [onPlaybackQualityChange](#onPlaybackQualityChange)
 - [mute](#mute)
 - [volume](#volume)
@@ -172,6 +174,14 @@ Possible values are:
 | HTML5_error       | The requested content cannot be played in an HTML5 player or another error related to the HTML5 player has occurred.                                                                                                                 |
 | video_not_found   | The video requested was not found. This error occurs when a video has been removed (for any reason) or has been marked as private.                                                                                                   |
 | embed_not_allowed | The owner of the requested video does not allow it to be played in embedded players.                                                                                                                                                 |
+
+## onFullScreenChange
+
+**_function(status: boolean)_**
+
+This event fires whenever the fullscreen option is clicked in the player.
+
+The data value that the API passes to the event listener function will be a boolean that identifies the new fullscreen status.
 
 ## onPlaybackQualityChange
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,10 @@ export interface YoutubeIframeProps {
    */
   onChangeState?: (event: String) => void;
   /**
+   * callback for when the fullscreen option is clicked in the player. It signals the new fullscreen state of the player.
+   */
+  onFullScreenChange?: (status: Boolean) => void;
+  /**
    * callback for when the video playback quality changes. It might signal a change in the viewer's playback environment.
    */
   onPlaybackQualityChange?: (quality: String) => void;

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ const [playing, setPlaying] = useState(true);
   onChangeState={event => console.log(event)}
   onReady={() => console.log("ready")}
   onError={e => console.log(e)}
+  onFullScreenChange={status => console.log(status)}
   onPlaybackQualityChange={q => console.log(q)}
   volume={50}
   playbackRate={1}
@@ -79,6 +80,7 @@ list of available APIs -
 - onChangeState
 - onReady
 - onError
+- onFullScreenChange
 - onPlaybackQualityChange
 - mute
 - volume

--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -98,6 +98,11 @@ export const MAIN_SCRIPT = (
       var firstScriptTag = document.getElementsByTagName('script')[0];
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
+      var isFullScreen = false;
+      function onFullScreenChange() {
+        isFullScreen = !isFullScreen;
+        window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'fullScreenChange', data: isFullScreen}));
+      }
 
       var player;
       function onYouTubeIframeAPIReady() {
@@ -130,10 +135,8 @@ export const MAIN_SCRIPT = (
             'onPlaybackRateChange': onPlaybackRateChange,
           }
         });
-      }
 
-      function onFullScreenChange() {
-        window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'fullScreenChange', data: !!document.fullscreenElement}))
+        document.getElementById('player').addEventListener('webkitfullscreenchange', onFullScreenChange);
       }
 
       function onPlayerError(event) {
@@ -156,14 +159,6 @@ export const MAIN_SCRIPT = (
       function onPlayerStateChange(event) {
         window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'playerStateChange', data: event.data}))
       }
-
-      document.addEventListener('fullscreenchange', onFullScreenChange)
-
-      document.addEventListener('mozfullscreenchange', onFullScreenChange)
-
-      document.addEventListener('msfullscreenchange', onFullScreenChange)
-
-      document.addEventListener('webkitfullscreenchange', onFullScreenChange)
     </script>
   </body>
 </html>`;

--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -132,6 +132,10 @@ export const MAIN_SCRIPT = (
         });
       }
 
+      function onFullScreenChange() {
+        window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'fullScreenChange', data: !!document.fullscreenElement}))
+      }
+
       function onPlayerError(event) {
         window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'playerError', data: event.data}))
       }
@@ -152,6 +156,14 @@ export const MAIN_SCRIPT = (
       function onPlayerStateChange(event) {
         window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'playerStateChange', data: event.data}))
       }
+
+      document.addEventListener('fullscreenchange', onFullScreenChange)
+
+      document.addEventListener('mozfullscreenchange', onFullScreenChange)
+
+      document.addEventListener('msfullscreenchange', onFullScreenChange)
+
+      document.addEventListener('webkitfullscreenchange', onFullScreenChange)
     </script>
   </body>
 </html>`;

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -31,6 +31,7 @@ const YoutubeIframe = (
     allowWebViewZoom = false,
     forceAndroidAutoplay = false,
     onChangeState = _event => {},
+    onFullScreenChange = _status => {},
     onPlaybackQualityChange = _quality => {},
     onPlaybackRateChange = _playbackRate => {},
   },
@@ -117,6 +118,9 @@ const YoutubeIframe = (
       const message = JSON.parse(event.nativeEvent.data);
       try {
         switch (message.eventType) {
+          case 'fullScreenChange':
+            onFullScreenChange(message.data);
+            break;
           case 'playerStateChange':
             onChangeState(PLAYER_STATES[message.data]);
             break;


### PR DESCRIPTION
Added functionality to detect fullscreen change events in the webview containing the youtube iframe.

Creates event listeners to detect fullscreen changes on `document` in the WebView and uses `postMessage` to detect the event along with the fullscreen status (boolean).

Need: This comes after I needed to change the orientation lock in an app that was always locked to portrait by default. 