### PR TITLE
Adding full screen listener.

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -13,6 +13,7 @@
   onReady={() => console.log("ready")}
   onError={e => console.log(e)}
   onPlaybackQualityChange={q => console.log(q)}
+  onFullScreenChange={isFullScreen => console.log(isFullScreen)}
   volume={50}
   playbackRate={1}
   initialPlayerParams={{
@@ -38,6 +39,7 @@
 - [onReady](#onReady)
 - [onError](#onError)
 - [onPlaybackQualityChange](#onPlaybackQualityChange)
+- [onFullScreenChange](#onFullScreenChange)
 - [mute](#mute)
 - [volume](#volume)
 - [playbackRate](#playbackRate)
@@ -53,6 +55,7 @@
 - [getDuration](#getDuration)
 - [getCurrentTime](#getCurrentTime)
 - [isMuted](#isMuted)
+- [isFullScreen](#isFullScreen)
 - [getVolume](#getVolume)
 - [getPlaybackRate](#getPlaybackRate)
 - [getAvailablePlaybackRates](#getAvailablePlaybackRates)
@@ -190,6 +193,12 @@ The data value that the API passes to the event listener function will be a stri
 | hd1080  |
 | highres |
 
+## onFullScreenChange
+
+**_function(isFullScreen: boolean)_**
+
+This event fires whenever the video enters or leaves full screen.
+
 ## mute
 
 **_Boolean_**
@@ -275,6 +284,8 @@ const App = () => {
 
           playerRef.current.isMuted().then(isMuted => console.log({isMuted}));
 
+          playerRef.current.isFullScreen().then(isFullScreen => console.log({isFullScreen}));
+
           playerRef.current.getVolume().then(getVolume => console.log({getVolume}));
 
           playerRef.current.getPlaybackRate().then(getPlaybackRate => console.log({getPlaybackRate}));
@@ -303,6 +314,10 @@ returns a promise that resolves to the elapsed time in seconds since the video s
 ## isMuted
 
 returns a promise that resolves to true if the video is muted, false if not.
+
+## isFullScreen
+
+returns a promise that resolves to true if the video is running in full screen, false if not.
 
 ## getVolume
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,10 @@ export interface YoutubeIframeProps {
    * callback for when the video playback rate changes.
    */
   onPlaybackRateChange?: (event: String) => void;
+    /**
+   * callback for when the video player enters or leaves full screen
+   */
+  onFullScreenChange?: (quality: Boolean) => void;
   /**
    * Flag to decide whether or not a user can zoom the video webview.
    */

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ const [playing, setPlaying] = useState(true);
   onReady={() => console.log("ready")}
   onError={e => console.log(e)}
   onPlaybackQualityChange={q => console.log(q)}
+  onFullScreenChange={isFullScreen => console.log(isFullScreen)}
   volume={50}
   playbackRate={1}
   initialPlayerParams={{
@@ -80,6 +81,7 @@ list of available APIs -
 - onReady
 - onError
 - onPlaybackQualityChange
+- onFullScreenChange
 - mute
 - volume
 - playbackRate
@@ -94,6 +96,7 @@ list of available APIs -
 - getDuration
 - getCurrentTime
 - isMuted
+- isFullScreen
 - getVolume
 - getPlaybackRate
 - getAvailablePlaybackRates

--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -11,6 +11,10 @@ true;
 window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'isMuted', data: player.isMuted()}));
 true;
 `,
+  isFullScreenScript: `
+window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'isFullScreen', data: !!(document.fullscreenElement && document.fullscreenElement.id === 'player')}));
+true;
+`,
   getVolumeScript: `
 window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'getVolume', data: player.getVolume()}));
 true;
@@ -130,6 +134,19 @@ export const MAIN_SCRIPT = (
             'onPlaybackRateChange': onPlaybackRateChange,
           }
         });
+
+        // document.addEventListener('fullscreenchange', onFullScreenChange)
+        // document.addEventListener('msfullscreenchange', onFullScreenChange)
+        // document.addEventListener('mozfullscreenchange', onFullScreenChange)
+        document.addEventListener('webkitfullscreenchange', onFullScreenChange)
+      }
+
+      function onFullScreenChange(event) {
+        if (document.fullscreenElement && document.fullscreenElement.id === 'player') {
+          window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'playerFullScreenChange', data: true}))
+        } else {
+          window.ReactNativeWebView.postMessage(JSON.stringify({eventType: 'playerFullScreenChange', data: false}))
+        }
       }
 
       function onPlayerError(event) {

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -31,6 +31,7 @@ const YoutubeIframe = (
     allowWebViewZoom = false,
     forceAndroidAutoplay = false,
     onChangeState = _event => {},
+    onFullScreenChange = _isFullScreen => {},
     onPlaybackQualityChange = _quality => {},
     onPlaybackRateChange = _playbackRate => {},
   },
@@ -59,6 +60,14 @@ const YoutubeIframe = (
         webViewRef.current.injectJavaScript(PLAYER_FUNCTIONS.isMutedScript);
         return new Promise(resolve => {
           eventEmitter.current.once('isMuted', resolve);
+        });
+      },
+      isFullScreen: () => {
+        webViewRef.current.injectJavaScript(
+          PLAYER_FUNCTIONS.isFullScreenScript,
+        );
+        return new Promise(resolve => {
+          eventEmitter.current.once('isFullScreen', resolve);
         });
       },
       getVolume: () => {
@@ -142,6 +151,9 @@ const YoutubeIframe = (
           case 'playbackRateChange':
             onPlaybackRateChange(message.data);
             break;
+          case 'playerFullScreenChange':
+            onFullScreenChange(message.data);
+            break;
           default:
             eventEmitter.current.emit(message.eventType, message.data);
             break;
@@ -156,6 +168,7 @@ const YoutubeIframe = (
       onPlaybackQualityChange,
       onError,
       onPlaybackRateChange,
+      onFullScreenChange,
       playListStartIndex,
       playList,
       play,


### PR DESCRIPTION
If a player is set in portrait mode in app after going into fullscreen mode it stays in the portrait scale. In order to fix that I've added a **document** listener to track **webkitfullscreenchange** event. 

There are also a couple of other events for different browsers, but this one seams to be working fine on Android, on iOS i currently have no ability to validate if event gets triggered properly.

Here's an example usage in my case:

```
import React, {useRef} from 'react';
import {PixelRatio, Dimensions} from 'react-native';

import YouTubeFrame from 'react-native-youtube-iframe';

import * as ScreenOrientation from 'expo-screen-orientation';

const {width} = Dimensions.get('window');

const height = PixelRatio.roundToNearestPixel(width / (16 / 9));

export default MediaPlayer = ({videoId, play} = {videoId="dQw4w9WgXcQ",play: true}) => {
  const player = useRef(null);

  const onFullScreenChange = isFullScreen => {
    ScreenOrientation.lockAsync(
      isFullScreen
        ? ScreenOrientation.OrientationLock.LANDSCAPE
        : ScreenOrientation.OrientationLock.PORTRAIT,
    ).catch(console.log);
  };

  return (
    <YouTubeFrame
      ref={player}
      play={play}
      width={width}
      height={height}
      videoId={videoId}
      onFullScreenChange={onFullScreenChange}
    />
  );
};
```
When player enters fullscreen mode I lock the orientation with expo orientation. 

Hope this helps someone out. Cheers! 