### PR TITLE
Add ref prop to type declarations

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -98,6 +98,25 @@ const App = () => {
 };
 ```
 
+Typescript usage.
+
+```typescript
+import React, {useRef} from 'react';
+import { YoutubeIframeRef } from 'react-native-youtube-iframe';
+const App = () => {
+  const playerRef = useRef<YoutubeIframeRef>(null);
+  return (
+    <YoutubePlayer height={400} width={400} ref={playerRef} videoId={'AVAc1gYLZK0'} />
+    <Button
+        title="get current player time"
+        onPress={() => {
+          playerRef?.current?.getCurrentTime().then(data => console.log({data}));
+        }}
+      />
+  );
+};
+```
+
 ## videoId
 
 **_String_**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,16 @@ import React from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
 import {WebViewProps} from 'react-native-webview';
 
+export interface YoutubeIframeRef {
+  getDuration: () => Promise<number>;
+  getCurrentTime: () => Promise<number>;
+  isMuted: () => Promise<boolean>;
+  getVolume: () => Promise<number>;
+  getPlaybackRate: () => Promise<number>;
+  getAvailablePlaybackRates: () => Promise<number[]>;
+  seekTo: (seconds: number, allowSeekAhead: boolean) => void;
+}
+
 export interface InitialPlayerParams {
   loop?: boolean;
   controls?: boolean;
@@ -104,6 +114,10 @@ export interface YoutubeIframeProps {
    * Flag to decide whether or not a user can zoom the video webview.
    */
   allowWebViewZoom?: Boolean;
+  /**
+   * Set this React Ref to use ref functions such as getDuration.
+   */
+  ref?: React.MutableRefObject<YoutubeIframeRef | null>;
 }
 
 declare const YoutubeIframe: React.SFC<YoutubeIframeProps>;


### PR DESCRIPTION
I ran into the following TypeScript error when attempting to use ref functions: `Property 'ref' does not exist on type 'IntrinsicAttributes & YoutubeIframeProps & { children?: ReactNode; }'.`

This PR adds the missing ref prop to `index.d.ts` and updates the documentation to explain TypeScript usage for the ref prop (feel free to leave out the documentation changes - I just thought it might help answer some questions).

Lastly, this project has been really helpful in developing my team's Expo app, so thanks @LonelyCpp!