### PR TITLE
TypeScript support: Fix type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ export interface YoutubeIframeProps {
    * Works only if the playlist is a list of video IDs.
    */
   playListStartIndex?: Number;
-  initialPlayerParams: InitialPlayerParams;
+  initialPlayerParams?: InitialPlayerParams;
   /**
    * Changes user string to make autoplay work on the iframe player for some android devices.
    */


### PR DESCRIPTION
`initialPlayerParams` was required but it should be optional property.

FYI: Default value is defined here.
https://github.com/LonelyCpp/react-native-youtube-iframe/blob/1bd53a690a6fffe039d38656829ee3ebf449541b/src/YoutubeIframe.js#L35