### PR TITLE
Issue/76, WebView has bounce at begin of page, end of page [iOS]

### DIFF
--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -191,7 +191,7 @@ const YoutubeIframe = (props, ref) => {
           return request.mainDocumentURL === 'about:blank';
         }}
         {...webViewProps}
-        bounces={webViewProps.bounces ?? false}
+        bounces={webViewProps?.bounces ?? false}
       />
     </View>
   );

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -191,6 +191,7 @@ const YoutubeIframe = (props, ref) => {
           return request.mainDocumentURL === 'about:blank';
         }}
         {...webViewProps}
+        bounces={webViewProps.bounces ?? false}
       />
     </View>
   );

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -190,8 +190,8 @@ const YoutubeIframe = (props, ref) => {
         onShouldStartLoadWithRequest={request => {
           return request.mainDocumentURL === 'about:blank';
         }}
+        bounces={false}
         {...webViewProps}
-        bounces={webViewProps?.bounces ?? false}
       />
     </View>
   );


### PR DESCRIPTION
# Issue about..
 issue #76 WebView has bounce at begin of page, end of page [iOS]

# Comment

Blocked scroll-bouncing in WebView with iOS by just adding `bounces={webViewProps?.bounces ?? false}`

If someone want to set `bounces` to `true`, it's possible. I just set default `bounces` value to `true`
