### PR TITLE
Added keep ratio props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,15 @@ export interface InitialPlayerParams {
 
 export interface YoutubeIframeProps {
   /**
+   * Allows youTube player to extend according to the given height.
+   *
+   * Note: Iframe player preserves the ratio of the video by default. If this prop is false, the ratio is not preserved and the given height is used for the player.
+   *
+   * @default true
+   */
+  keepRatio?: boolean;
+
+  /**
    * height of the webview container
    *
    * Note: Embedded players must have a viewport that is at least 200px by 200px. If the player displays controls, it must be large enough to fully display the controls without shrinking the viewport below the minimum size. We recommend 16:9 players be at least 480 pixels wide and 270 pixels tall.

--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -67,6 +67,7 @@ export const MAIN_SCRIPT = (
   initialPlayerParams,
   allowWebViewZoom,
   contentScale,
+  keepRatio,
 ) => {
   const {
     end,
@@ -103,6 +104,15 @@ export const MAIN_SCRIPT = (
     scale += `, maximum-scale=${contentScale_s}`;
   }
 
+  const resetRatio = `
+    html, body, .container {
+      height: 100%;
+    } 
+    .container{
+      padding-bottom: 0;
+    }
+  `;
+
   return `
 <!DOCTYPE html>
 <html>
@@ -128,6 +138,7 @@ export const MAIN_SCRIPT = (
           width: 100%;
           height: 100%;
       }
+      ${keepRatio ? '' : resetRatio}
     </style>
   </head>
   <body>

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -40,6 +40,7 @@ const YoutubeIframe = (props, ref) => {
     onFullScreenChange = _status => {},
     onPlaybackQualityChange = _quality => {},
     onPlaybackRateChange = _playbackRate => {},
+    keepRatio = true,
   } = props;
 
   const webViewRef = useRef(null);
@@ -182,6 +183,7 @@ const YoutubeIframe = (props, ref) => {
             initialPlayerParams,
             allowWebViewZoom,
             contentScale,
+            keepRatio,
           ),
         }}
         userAgent={


### PR DESCRIPTION
I added this props because we could not change the height of the video. I will put the pictures below. If you want to solve this in a different way, don't hesitate to turn it off.

### Before 
- yellow area is height of webview. But video is small of webview.
![before](https://cdn.discordapp.com/attachments/504592835782115330/781356820094255104/Screenshot_20201126-061241.png)

### After
![1](https://cdn.discordapp.com/attachments/504592835782115330/781356940793872424/Screenshot_20201126-061317.png)

other image
![2](https://cdn.discordapp.com/attachments/504592835782115330/781357045482913792/Screenshot_20201126-061345.png)

