### PR TITLE
feat: add a setHeight method to the player ref to resize it

### DIFF
--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -42,6 +42,12 @@ true;
     return `player.seekTo(${seconds}, ${allowSeekAhead}); true;`;
   },
 
+  setHeight: height => {
+    return typeof height === 'number' ?
+      `document.querySelector('.container').style.paddingBottom = '${height}px'; true;` :
+      'true ;';
+  },
+
   setPlaybackRate: playbackRate => {
     return `player.setPlaybackRate(${playbackRate}); true;`;
   },

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -112,6 +112,11 @@ const YoutubeIframe = (props, ref) => {
           PLAYER_FUNCTIONS.seekToScript(seconds, allowSeekAhead),
         );
       },
+      setHeight: (height) => {
+        webViewRef.current.injectJavaScript(
+          PLAYER_FUNCTIONS.setHeight(height),
+        );
+      },
     }),
     [],
   );


### PR DESCRIPTION
I wanted to resize the player on the fly, for example to support vertical videos like https://youtu.be/GeYK9JdPVMw.

I added a new method to the YoutubePlayer ref in order to do that. Let me know if that's a feature you'd be interested in and if there's anything you'd like me to change.

Cheers!