### PR TITLE
make videoId props optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export interface YoutubeIframeProps {
   /**
    * Specifies the YouTube Video ID of the video to be played.
    */
-  videoId: string;
+  videoId?: string;
   /**
    * Specifies the playlist to play. It can be either the playlist ID or a list of video IDs
    *


### PR DESCRIPTION
Hi! 
Shouldnt we make videoId optional if we want to pass just a playList?
Ideally a conditional type should probably be created so we must have videoId or playList, but not both?
Or is there a use case for both?