### PR TITLE
improvement: update TS typing for YoutubeIframeProps["onChangeState"]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ export interface YoutubeIframeProps {
   /**
    * callback for when the player's state changes.
    */
-  onChangeState?: (event: string) => void;
+  onChangeState?: (event: PLAYER_STATES) => void;
   /**
    * callback for when the fullscreen option is clicked in the player. It signals the new fullscreen state of the player.
    */


### PR DESCRIPTION
Appropriately updates the typing of `YoutubeIframeProps["onChangeState"]` 