### PR TITLE
Fix wrong type of onPlaybackRateChange prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,7 +138,7 @@ export interface YoutubeIframeProps {
   /**
    * callback for when the video playback rate changes.
    */
-  onPlaybackRateChange?: (event: string) => void;
+  onPlaybackRateChange?: (playbackRate: number) => void;
   /**
    * Flag to decide whether or not a user can zoom the video webview.
    */


### PR DESCRIPTION
[in the document](https://lonelycpp.github.io/react-native-youtube-iframe/component-props#onplaybackratechange), type of `onPlaybackRateChange` is `(rate: number) => void`.
but the type definition is written `(event: string) => void`