### PR TITLE
Add webViewRef to YoutubeIframe

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
-import {WebViewProps} from 'react-native-webview';
+import WebView, {WebViewProps} from 'react-native-webview';
 
 export enum PLAYER_STATES {
   ENDED = 'ended',
@@ -100,6 +100,10 @@ export interface YoutubeIframeProps {
    * Props that are supplied to the underlying webview (react-native-webview). A full list of props can be found [here](https://github.com/react-native-community/react-native-webview/blob/master/docs/Reference.md#props-index)
    */
   webViewProps?: WebViewProps;
+  /**
+   * A React ref object that provides direct access to the underlying WebView instance.
+   */
+  webViewRef?: React.RefObject<WebView>;
   /**
    * This sets the suggested playback rate for the current video. If the playback rate changes, it will only change for the video that is already cued or being played.
    */

--- a/src/YoutubeIframe.js
+++ b/src/YoutubeIframe.js
@@ -29,6 +29,7 @@ const YoutubeIframe = (props, ref) => {
     mute = false,
     volume = 100,
     viewContainerStyle,
+    webViewRef,
     webViewStyle,
     webViewProps,
     useLocalHTML,
@@ -52,8 +53,10 @@ const YoutubeIframe = (props, ref) => {
   const lastPlayListRef = useRef(playList);
   const initialPlayerParamsRef = useRef(initialPlayerParams || {});
 
-  const webViewRef = useRef(null);
+  const internalWebViewRef = useRef(null);
   const eventEmitter = useRef(new EventEmitter());
+
+  webViewRef ||= internalWebViewRef;
 
   const sendPostMessage = useCallback(
     (eventName, meta) => {


### PR DESCRIPTION
Adds `webViewRef` prop to `YoutubeIframe` for direct `WebView` access, with TypeScript support. Updates `index.d.ts` and `src/YoutubeIframe.js` to include the prop and fallback logic.