### PR TITLE
Feat/privacy enhanced embed host

### DIFF
--- a/docs/props.mdx
+++ b/docs/props.mdx
@@ -270,6 +270,13 @@ changing these parameters might cause the player to restart or not change at all
 | iv_load_policy     | Number  |         | https://developers.google.com/youtube/player_parameters#iv_load_policy |
 | modestbranding     | boolean | false   | https://developers.google.com/youtube/player_parameters#modestbranding |
 | rel                | boolean | false   | https://developers.google.com/youtube/player_parameters#rel            |
+| privacyEnhanced    | boolean | false   | embed from `youtube-nocookie.com` (see below)                          |
+
+#### `privacyEnhanced`
+
+When `true`, the player is created with `host: 'https://www.youtube-nocookie.com'`, so the embed is served from YouTube's [privacy-enhanced domain](https://support.google.com/youtube/answer/171780#zippy=%2Cturn-on-privacy-enhanced-mode) instead of the default `www.youtube.com`. In this mode YouTube does not use a viewer's playback of the embed to personalise their browsing experience.
+
+This only takes effect together with [`useLocalHTML`](#uselocalhtml), since the remotely hosted player page does not read the option. Pair it with `baseUrlOverride="https://www.youtube-nocookie.com"` so the document origin matches the embed host.
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,13 @@ export interface InitialPlayerParams {
    */
   deprecated?: boolean;
   rel?: boolean;
+  /**
+   * Embed the player from YouTube's privacy-enhanced domain
+   * (www.youtube-nocookie.com) instead of www.youtube.com, by passing
+   * `host` to the IFrame API. Only takes effect with `useLocalHTML`,
+   * since the remotely hosted player page does not read this option.
+   */
+  privacyEnhanced?: boolean;
 }
 
 export interface YoutubeIframeProps {

--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -97,10 +97,15 @@ export const MAIN_SCRIPT = (
     controls = true,
     showClosedCaptions,
     preventFullScreen = false,
+    privacyEnhanced = false,
   } = initialPlayerParams;
 
   // _s postfix to refer to "safe"
   const rel_s = rel ? 1 : 0;
+  // derived from a boolean so no caller-supplied text reaches the HTML
+  const host_s = privacyEnhanced
+    ? 'https://www.youtube-nocookie.com'
+    : 'https://www.youtube.com';
   const loop_s = loop ? 1 : 0;
   const videoId_s = videoId || '';
   const controls_s = controls ? 1 : 0;
@@ -192,6 +197,7 @@ export const MAIN_SCRIPT = (
         player = new YT.Player('player', {
           width: '1000',
           height: '1000',
+          host: '${host_s}',
           videoId: '${videoId_s}',
           playerVars: {
             ${listParam}


### PR DESCRIPTION
## Motivation

There's currently no way to make the player embed from YouTube's privacy-enhanced
domain (`www.youtube-nocookie.com`). `baseUrlOverride` only sets the document origin
of the local player page — the `YT.Player` in `PlayerScripts.js` is always constructed
against the default `www.youtube.com`, because no `host` option is passed. Apps that
need cookieless / privacy-enhanced embedding for compliance reasons (COPPA, GDPR, apps
aimed at children or schools) can't get it from this library today.

This is the same capability Google exposes in its own `@angular/youtube-player`
(`disableCookies`) and in the plain `<iframe>` embed flow, surfaced here as an opt-in flag.

## Change

Adds an `initialPlayerParams.privacyEnhanced` boolean (default `false`). When `true`,
the locally generated player page constructs the player with
`host: 'https://www.youtube-nocookie.com'`. The host is derived from the boolean, so no
caller-supplied string is interpolated into the generated HTML. It only takes effect with
`useLocalHTML` (the remotely hosted page doesn't read the option); pairing it with
`baseUrlOverride="https://www.youtube-nocookie.com"` keeps the document origin aligned
with the embed host.

- `src/PlayerScripts.js` — new `privacyEnhanced` param → `host` in the player config
- `index.d.ts` — typed the new option on `InitialPlayerParams`
- `docs/props.mdx` — documented it in the `initialPlayerParams` table

## Compatibility

Fully backward-compatible and opt-in: omitting the flag (or `false`) yields exactly
today's behaviour (`host: 'https://www.youtube.com'`, the IFrame API's implicit default).

## Note

One request still goes to `www.youtube.com` regardless: the `iframe_api` loader script
(`tag.src`), which has no host alternative — same as any nocookie embed. The player, the
video stream, and cookies move to the nocookie domain.